### PR TITLE
Remove _should_stop global

### DIFF
--- a/rpc/telegram.py
+++ b/rpc/telegram.py
@@ -174,10 +174,10 @@ class TelegramHandler(object):
         :param update: message update
         :return: None
         """
-        from main import get_instance, stop_instance
+        from main import get_instance
         if get_instance().is_alive():
             TelegramHandler.send_msg('`Stopping trader ...`', bot=bot)
-            stop_instance()
+            get_instance().stop()
         else:
             TelegramHandler.send_msg('*Status:* `already stopped`', bot=bot)
 


### PR DESCRIPTION
Moved the condition of whether the trader thread should stop to it's internal attribute. So instead of an module global variable, you can now just call get_instance().stop().